### PR TITLE
Handle null API responses gracefully

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,8 +35,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release list --json tagName,isPrerelease -q '.[] | select(.isPrerelease) | .tagName' | \
-            grep "pr${{ github.event.pull_request.number }}\." | \
+          gh release list --json tagName,isPrerelease \
+            -q '.[] | select(.isPrerelease) | .tagName | select(endswith("-pr${{ github.event.pull_request.number }}"))' | \
             while read -r tag; do
               echo "Deleting pre-release $tag"
               gh release delete "$tag" --yes --cleanup-tag || true

--- a/custom_components/lynkco/__init__.py
+++ b/custom_components/lynkco/__init__.py
@@ -163,7 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinators: dict[str, LynkCoCoordinator] = {}
     for vehicle_entry in vehicles:
-        vehicle = vehicle_entry.get("vehicle", {})
+        vehicle = vehicle_entry.get("vehicle") or {}
         vin = vehicle.get("vin")
         model = vehicle.get("model", "Unknown")
         if not vin:

--- a/custom_components/lynkco/api.py
+++ b/custom_components/lynkco/api.py
@@ -132,11 +132,13 @@ class LynkCoAPI:
                         method, url, headers=headers, **kwargs
                     ) as retry:
                         retry.raise_for_status()
-                        return await retry.json()
+                        retry_data = await retry.json()
+                        return retry_data if retry_data is not None else {}
             resp.raise_for_status()
             if resp.content_length == 0:
                 return {}
-            return await resp.json()
+            data = await resp.json()
+            return data if data is not None else {}
 
     async def refresh_tokens(self) -> bool:
         url = f"{LOGIN_B2C_URL}oauth2/v2.0/token"

--- a/custom_components/lynkco/coordinator.py
+++ b/custom_components/lynkco/coordinator.py
@@ -77,7 +77,7 @@ class LynkCoCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed(f"API error: {err}") from err
 
         # Store propulsion type for entity filtering
-        propulsion = data["metadata"].get("vehicle", {}).get("propulsionType")
+        propulsion = (data["metadata"].get("vehicle") or {}).get("propulsionType")
         if propulsion:
             self.propulsion = propulsion
 

--- a/custom_components/lynkco/device_tracker.py
+++ b/custom_components/lynkco/device_tracker.py
@@ -44,18 +44,16 @@ class LynkCoDeviceTracker(CoordinatorEntity, TrackerEntity):
     def source_type(self) -> SourceType:
         return SourceType.GPS
 
+    def _coordinates(self) -> dict:
+        data = self.coordinator.data or {}
+        location = data.get("location") or {}
+        vehicle_location = location.get("vehicleLocation") or {}
+        return vehicle_location.get("coordinates") or {}
+
     @property
     def latitude(self) -> float | None:
-        if self.coordinator.data is None:
-            return None
-        loc = self.coordinator.data.get("location", {}).get("vehicleLocation", {})
-        coords = loc.get("coordinates", {})
-        return coords.get("latitude")
+        return self._coordinates().get("latitude")
 
     @property
     def longitude(self) -> float | None:
-        if self.coordinator.data is None:
-            return None
-        loc = self.coordinator.data.get("location", {}).get("vehicleLocation", {})
-        coords = loc.get("coordinates", {})
-        return coords.get("longitude")
+        return self._coordinates().get("longitude")

--- a/custom_components/lynkco/device_tracker.py
+++ b/custom_components/lynkco/device_tracker.py
@@ -1,7 +1,6 @@
 """Device tracker platform for Lynk & Co integration."""
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/lynkco/lock.py
+++ b/custom_components/lynkco/lock.py
@@ -48,11 +48,9 @@ class LynkCoLock(CoordinatorEntity, LockEntity):
     def is_locked(self) -> bool | None:
         if self.coordinator.data is None:
             return None
-        status = (
-            self.coordinator.data.get("vehicle_data", {})
-            .get("centralLock", {})
-            .get("status")
-        )
+        vehicle_data = self.coordinator.data.get("vehicle_data") or {}
+        central_lock = vehicle_data.get("centralLock") or {}
+        status = central_lock.get("status")
         if status is None:
             return None
         return status == "LOCKED"

--- a/custom_components/lynkco/manifest.json
+++ b/custom_components/lynkco/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pkce>=1.0.3"
   ],
-  "version": "0.5.2"
+  "version": "0.5.1"
 }

--- a/custom_components/lynkco/manifest.json
+++ b/custom_components/lynkco/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pkce>=1.0.3"
   ],
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/custom_components/lynkco/sensor.py
+++ b/custom_components/lynkco/sensor.py
@@ -26,7 +26,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.BATTERY,
         "unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: _pct(d.get("charge", {}).get("batteryState", {}).get("stateOfCharge")),
+        "value_fn": lambda d: _pct(_dig(d, "charge", "batteryState", "stateOfCharge")),
     },
     {
         "key": "battery_range",
@@ -35,7 +35,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.DISTANCE,
         "unit": UnitOfLength.KILOMETERS,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("charge", {}).get("batteryState", {}).get("remainingRange"),
+        "value_fn": lambda d: _dig(d, "charge", "batteryState", "remainingRange"),
     },
     {
         "key": "charging_status",
@@ -44,7 +44,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.ENUM,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _lower(d.get("charge", {}).get("batteryState", {}).get("status")),
+        "value_fn": lambda d: _lower(_dig(d, "charge", "batteryState", "status")),
     },
     {
         "key": "charging_speed",
@@ -53,7 +53,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.POWER,
         "unit": UnitOfPower.KILO_WATT,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: (d.get("charge", {}).get("batteryState", {}).get("chargingSpeed") or {}).get("kW"),
+        "value_fn": lambda d: _dig(d, "charge", "batteryState", "chargingSpeed", "kW"),
     },
     {
         "key": "charging_time_remaining",
@@ -62,7 +62,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.DURATION,
         "unit": UnitOfTime.MINUTES,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("charge", {}).get("batteryState", {}).get("remainingChargingTime"),
+        "value_fn": lambda d: _dig(d, "charge", "batteryState", "remainingChargingTime"),
     },
     {
         "key": "charge_limit",
@@ -71,7 +71,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": None,
         "unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: (d.get("charge", {}).get("batteryState", {}).get("chargeLimit") or {}).get("value"),
+        "value_fn": lambda d: _dig(d, "charge", "batteryState", "chargeLimit", "value"),
     },
     {
         "key": "interior_temperature",
@@ -80,7 +80,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.TEMPERATURE,
         "unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("climate", {}).get("interiorTemperature"),
+        "value_fn": lambda d: _dig(d, "climate", "interiorTemperature"),
     },
     {
         "key": "target_temperature",
@@ -89,7 +89,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.TEMPERATURE,
         "unit": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("climate", {}).get("targetTemperature"),
+        "value_fn": lambda d: _dig(d, "climate", "targetTemperature"),
     },
     {
         "key": "climate_status",
@@ -98,7 +98,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.ENUM,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _lower(d.get("climate", {}).get("status")),
+        "value_fn": lambda d: _lower(_dig(d, "climate", "status")),
     },
     {
         "key": "heater_steering_wheel",
@@ -174,7 +174,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.ENUM,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _lower(d.get("vehicle_data", {}).get("centralLock", {}).get("status")),
+        "value_fn": lambda d: _lower(_dig(d, "vehicle_data", "centralLock", "status")),
     },
     {
         "key": "address",
@@ -183,7 +183,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": None,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: (d.get("location", {}).get("vehicleLocation") or {}).get("longAddress"),
+        "value_fn": lambda d: _dig(d, "location", "vehicleLocation", "longAddress"),
     },
     {
         "key": "fuel_level",
@@ -192,7 +192,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": None,
         "unit": PERCENTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: _pct(d.get("fuel", {}).get("fuelState", {}).get("percentageOfRemainingFuel")),
+        "value_fn": lambda d: _pct(_dig(d, "fuel", "fuelState", "percentageOfRemainingFuel")),
         "fuel_only": True,
     },
     {
@@ -202,7 +202,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.DISTANCE,
         "unit": UnitOfLength.KILOMETERS,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("fuel", {}).get("fuelState", {}).get("remainingRange"),
+        "value_fn": lambda d: _dig(d, "fuel", "fuelState", "remainingRange"),
         "fuel_only": True,
     },
     {
@@ -212,7 +212,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": None,
         "unit": "L/100km",
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("fuel", {}).get("fuelState", {}).get("averageConsumption"),
+        "value_fn": lambda d: _dig(d, "fuel", "fuelState", "averageConsumption"),
         "fuel_only": True,
     },
     {
@@ -222,7 +222,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.ENUM,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _lower(d.get("fuel", {}).get("fuelInfo", {}).get("fuelType")),
+        "value_fn": lambda d: _lower(_dig(d, "fuel", "fuelInfo", "fuelType")),
         "fuel_only": True,
     },
     {
@@ -232,7 +232,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.DISTANCE,
         "unit": UnitOfLength.KILOMETERS,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "value_fn": lambda d: d.get("metadata", {}).get("vehicle", {}).get("odometer"),
+        "value_fn": lambda d: _dig(d, "metadata", "vehicle", "odometer"),
     },
     {
         "key": "battery_capacity",
@@ -241,7 +241,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": None,
         "unit": UnitOfEnergy.KILO_WATT_HOUR,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: _round(d.get("metadata", {}).get("batteryInfo", {}).get("batteryCapacity")),
+        "value_fn": lambda d: _round(_dig(d, "metadata", "batteryInfo", "batteryCapacity")),
     },
     {
         "key": "battery_energy",
@@ -259,7 +259,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": None,
         "unit": UnitOfVolume.LITERS,
         "state_class": SensorStateClass.MEASUREMENT,
-        "value_fn": lambda d: d.get("metadata", {}).get("fuelInfo", {}).get("tankCapacity"),
+        "value_fn": lambda d: _dig(d, "metadata", "fuelInfo", "tankCapacity"),
         "fuel_only": True,
     },
     {
@@ -289,7 +289,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.TIMESTAMP,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _parse_ts(d.get("fuel", {}).get("fuelState", {}).get("updatedAt")),
+        "value_fn": lambda d: _parse_ts(_dig(d, "fuel", "fuelState", "updatedAt")),
         "fuel_only": True,
         "entity_registry_enabled_default": False,
     },
@@ -300,7 +300,7 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.TIMESTAMP,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _parse_ts((d.get("location", {}).get("vehicleLocation") or {}).get("updatedAt")),
+        "value_fn": lambda d: _parse_ts(_dig(d, "location", "vehicleLocation", "updatedAt")),
         "entity_registry_enabled_default": False,
     },
     {
@@ -310,11 +310,19 @@ SENSOR_TYPES: list[dict] = [
         "device_class": SensorDeviceClass.TIMESTAMP,
         "unit": None,
         "state_class": None,
-        "value_fn": lambda d: _parse_ts(d.get("climate", {}).get("updatedAt")),
+        "value_fn": lambda d: _parse_ts(_dig(d, "climate", "updatedAt")),
         "entity_registry_enabled_default": False,
     },
 ]
 
+
+def _dig(data, *keys):
+    """Safely traverse nested dicts, tolerating None or missing keys at any level."""
+    for key in keys:
+        if not isinstance(data, dict):
+            return None
+        data = data.get(key)
+    return data
 
 def _pct(val):
     if val is not None:
@@ -332,15 +340,11 @@ def _lower(val):
     return None
 
 def _heater_status(d, key):
-    heaters = d.get("climate", {}).get("heaters") or {}
-    heater = heaters.get(key)
-    if heater is None:
-        return None
-    return _lower(heater.get("status"))
+    return _lower(_dig(d, "climate", "heaters", key, "status"))
 
 def _battery_kwh(d):
-    capacity = d.get("metadata", {}).get("batteryInfo", {}).get("batteryCapacity")
-    soc = d.get("charge", {}).get("batteryState", {}).get("stateOfCharge")
+    capacity = _dig(d, "metadata", "batteryInfo", "batteryCapacity")
+    soc = _dig(d, "charge", "batteryState", "stateOfCharge")
     if capacity is not None and soc is not None:
         return round(capacity * soc, 1)
     return None
@@ -356,8 +360,8 @@ def _parse_ts(val):
         return None
 
 def _fuel_liters(d):
-    capacity = d.get("metadata", {}).get("fuelInfo", {}).get("tankCapacity")
-    pct = d.get("fuel", {}).get("fuelState", {}).get("percentageOfRemainingFuel")
+    capacity = _dig(d, "metadata", "fuelInfo", "tankCapacity")
+    pct = _dig(d, "fuel", "fuelState", "percentageOfRemainingFuel")
     if capacity is not None and pct is not None:
         return round(capacity * pct, 1)
     return None
@@ -370,7 +374,7 @@ async def async_setup_entry(
     entities = []
     for vin, coordinator in data["coordinators"].items():
         is_bev = coordinator.propulsion == "BEV"
-        heaters = (coordinator.data or {}).get("climate", {}).get("heaters") or {}
+        heaters = _dig(coordinator.data, "climate", "heaters") or {}
         for sensor_type in SENSOR_TYPES:
             if sensor_type.get("fuel_only") and is_bev:
                 continue


### PR DESCRIPTION
Fixes #18

## Problem

The Lynk & Co API can return `null` for an entire endpoint body, or `null` for individual nested fields (e.g. `coordinates`, `batteryState`), when the car is asleep or the connection is briefly interrupted.

`dict.get(key, {})` only falls back to `{}` when the key is **missing** — not when it is **present but `null`**. So the chained lookups raised, as reported in the issue:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This was a systemic pattern: the two tracebacks in the issue (`device_tracker.py` coordinates and `sensor.py` charging speed) were just the first spots to hit it; the same fragile access was repeated across ~25 sensor lookups.

## Fix

Two layers of defense:

**1. Stop the API layer from ever returning `None`**
- `api.py`: both the normal and 401-retry paths coerce a `null` JSON body to `{}`, so every endpoint call returns a dict. This guarantees top-level sections (`charge`, `location`, `metadata`, …) are always dicts — on the initial fetch, targeted refreshes, and `get_vehicles()`.

**2. Make nested lookups null-tolerant**
- `sensor.py`: added a small `_dig(data, *keys)` helper that safely walks nested dicts (tolerating `None`/missing at any level) and rewrote every `value_fn` to use it. New sensors are now null-safe by construction.
- `device_tracker.py`: `latitude`/`longitude` go through a null-safe `_coordinates()` helper.
- `lock.py`: null-safe `centralLock` lookup.
- `coordinator.py`: null-safe `propulsionType` lookup.
- `__init__.py`: null-safe `vehicle` lookup during setup.

## Also: fix deprecated `TrackerEntity` import

`device_tracker.py` imported `TrackerEntity` from `homeassistant.components.device_tracker.config_entry`, which is deprecated and logs:

> The deprecated alias TrackerEntity was used from lynkco. It will be removed in HA Core 2027.6. Use homeassistant.components.device_tracker.TrackerEntity instead

Now imported directly from `homeassistant.components.device_tracker` as recommended.

## Also: fix pre-release workflow re-run failure

The `Delete existing pre-release for this PR` step filtered tags with `grep "pr<N>\."`, but the pre-release tags end in `-pr<N>` with no trailing dot (e.g. `v0.5.2-pr19`), so the filter never matched. Stale pre-releases were never deleted and the next run's `Create pre-release` step failed with `HTTP 422: Release.tag_name already exists`. Now filtered with jq `endswith("-pr<N>")`.

## Verification
- All modules pass `py_compile`.
- A test reproducing both exact tracebacks (plus `vehicleLocation=null`, whole-section `=null`, and `data=None`) now returns `None` gracefully instead of crashing, while valid data still produces correct values.

The `manifest.json` version is intentionally left at `0.5.1`; the release workflow sets the version at release time.