### PR TITLE
feat: fast-poll only the relevant endpoints (driving / climate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ Other models are currently not available on the EU market, although it is likely
 
 ## Polling
 
-The full vehicle snapshot is polled every 15 minutes by default. On top of that, only the endpoints relevant to what's happening are fast-polled (about every 60 seconds), instead of refetching everything:
+The full vehicle data is polled every 15 minutes by default. On top of that, only endpoints relevant to what's happening are fast-polled (about every 60 seconds), instead of refetching everything:
 - **While driving:** location, drive state and battery. The final location is fetched once when you reach your destination (on LynkOS 1.4.0+ the car only reports location when it stops).
 - **While the climate/conditioning system is active:** the climate state.
-
-Everything else stays on the 15-minute cycle. The "polling interval while driving" option controls the fast cadence for the driving endpoints.
 
 When you perform an action (e.g. lock the doors or start the heaters), only the relevant data is refreshed — not everything. The integration checks for a state change after 3 seconds, and if the car hasn't processed the command yet, retries after 5 and then 10 seconds before giving up. Fire-and-forget actions like flashing the lights or honking the horn don't trigger a refresh at all.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Other models are currently not available on the EU market, although it is likely
 
 ## Polling
 
-Vehicle data is polled every 15 minutes by default. When the car is running, the polling interval automatically increases to every 60 seconds for more accurate location tracking, and reverts to 15 minutes when the car stops.
+The full vehicle snapshot is polled every 15 minutes by default. On top of that, only the endpoints relevant to what's happening are fast-polled (about every 60 seconds), instead of refetching everything:
+- **While driving:** location, drive state and battery. The final location is fetched once when you reach your destination (on LynkOS 1.4.0+ the car only reports location when it stops).
+- **While the climate/conditioning system is active:** the climate state.
+
+Everything else stays on the 15-minute cycle. The "polling interval while driving" option controls the fast cadence for the driving endpoints.
 
 When you perform an action (e.g. lock the doors or start the heaters), only the relevant data is refreshed — not everything. The integration checks for a state change after 3 seconds, and if the car hasn't processed the command yet, retries after 5 and then 10 seconds before giving up. Fire-and-forget actions like flashing the lights or honking the horn don't trigger a refresh at all.
 

--- a/custom_components/lynkco/__init__.py
+++ b/custom_components/lynkco/__init__.py
@@ -175,6 +175,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = LynkCoCoordinator(hass, entry, api, vin, model)
         await coordinator.async_config_entry_first_refresh()
         coordinators[vin] = coordinator
+        # Endpoint-specific fast polling (driving / climate active); stopped on unload
+        entry.async_on_unload(coordinator.start_fast_poll())
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "api": api,
@@ -183,12 +185,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Update coordinator interval when options change
+    # Apply the (full-snapshot) scan interval when options change
     async def _options_updated(_hass, _entry):
         scan_minutes = _entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL // 60)
         for coordinator in coordinators.values():
-            if not coordinator._driving:
-                coordinator.update_interval = timedelta(minutes=scan_minutes)
+            coordinator.update_interval = timedelta(minutes=scan_minutes)
 
     entry.async_on_unload(entry.add_update_listener(_options_updated))
 

--- a/custom_components/lynkco/const.py
+++ b/custom_components/lynkco/const.py
@@ -40,6 +40,7 @@ MODEL_NAMES = {
 
 DEFAULT_SCAN_INTERVAL = 900  # 15 minutes
 DRIVING_SCAN_INTERVAL = 60  # 1 minute when car is running
+CLIMATE_SCAN_INTERVAL = 60  # 1 minute while climate/conditioning is active
 
 # Config keys
 CONF_ACCESS_TOKEN = "access_token"

--- a/custom_components/lynkco/coordinator.py
+++ b/custom_components/lynkco/coordinator.py
@@ -3,21 +3,23 @@
 import asyncio
 import logging
 from collections.abc import Callable, Coroutine
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.util import dt as dt_util
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import LynkCoAPI
-from .const import CONF_DRIVING_INTERVAL, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DRIVING_SCAN_INTERVAL, DOMAIN
+from .const import CLIMATE_SCAN_INTERVAL, CONF_DRIVING_INTERVAL, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DRIVING_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 REFRESH_RETRY_DELAYS = [3, 5, 10]
+FAST_POLL_BASE_INTERVAL = timedelta(seconds=CLIMATE_SCAN_INTERVAL)  # finest fast-poll cadence
 
 
 class LynkCoCoordinator(DataUpdateCoordinator):
@@ -43,7 +45,7 @@ class LynkCoCoordinator(DataUpdateCoordinator):
         self.model = model
         self.propulsion: str | None = None  # Set after first fetch (e.g. "PHEV", "BEV")
         self.entry = entry
-        self._driving = False
+        self._last_fast_poll: dict[str, datetime] = {}
 
     async def _async_fetch_all(self) -> dict:
         vehicle_data = await self.api.get_vehicle_data(self.vin)
@@ -81,19 +83,72 @@ class LynkCoCoordinator(DataUpdateCoordinator):
         if propulsion:
             self.propulsion = propulsion
 
-        # Adjust polling interval based on driving state
-        scan_minutes = self.entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL // 60)
-        drive_minutes = self.entry.options.get(CONF_DRIVING_INTERVAL, DRIVING_SCAN_INTERVAL // 60)
-        driving = data["vehicle_data"].get("driveModeEnabled", False)
-        if driving and not self._driving:
-            _LOGGER.debug("Car is running, increasing poll frequency to %dm", drive_minutes)
-            self.update_interval = timedelta(minutes=drive_minutes)
-        elif not driving and self._driving:
-            _LOGGER.debug("Car stopped, reverting poll frequency to %dm", scan_minutes)
-            self.update_interval = timedelta(minutes=scan_minutes)
-        self._driving = driving
-
         return data
+
+    def start_fast_poll(self) -> Callable[[], None]:
+        """Start the endpoint-specific fast-poll timer; returns an unsub callable.
+
+        The full snapshot keeps polling on ``update_interval`` as a backstop; this
+        timer additionally refreshes only the endpoints relevant to whatever is
+        currently active (driving / climate), each at its own cadence.
+        """
+        return async_track_time_interval(self.hass, self._async_fast_poll, FAST_POLL_BASE_INTERVAL)
+
+    def _fast_poll_targets(self) -> list[tuple[str, str, timedelta]]:
+        """(data_key, api_method, period) for each endpoint to fast-poll right now."""
+        data = self.data or {}
+        targets: list[tuple[str, str, timedelta]] = []
+        if (data.get("vehicle_data") or {}).get("driveModeEnabled", False):
+            drive = timedelta(
+                minutes=self.entry.options.get(CONF_DRIVING_INTERVAL, DRIVING_SCAN_INTERVAL // 60)
+            )
+            # vehicle_data polls at the base cadence so drive-end is detected promptly
+            targets.append(("vehicle_data", "get_vehicle_data", FAST_POLL_BASE_INTERVAL))
+            targets.append(("location", "get_location", drive))
+            targets.append(("charge", "get_charge_state", drive))
+        status = (data.get("climate") or {}).get("status")
+        if str(status or "").upper().startswith("ACTIVE"):
+            targets.append(("climate", "get_climate_state", FAST_POLL_BASE_INTERVAL))
+        return targets
+
+    async def _async_fast_poll(self, now: datetime) -> None:
+        """Refresh only the endpoints relevant to the active trigger(s)."""
+        if self.data is None:
+            return
+
+        slack = timedelta(seconds=1)  # tolerate timer jitter so a 60s target fires each 60s tick
+        due: dict[str, str] = {}
+        for key, fn_name, period in self._fast_poll_targets():
+            last = self._last_fast_poll.get(key)
+            if last is None or (now - last) >= (period - slack):
+                due[key] = fn_name
+        if not due:
+            return
+
+        was_driving = (self.data.get("vehicle_data") or {}).get("driveModeEnabled", False)
+        updates: dict[str, Any] = {}
+        for key, fn_name in due.items():
+            try:
+                updates[key] = await getattr(self.api, fn_name)(self.vin)
+                self._last_fast_poll[key] = now
+            except Exception:
+                _LOGGER.debug("Fast poll of %s failed", key)
+        if not updates:
+            return
+
+        changed = any(updates[k] != self.data.get(k) for k in updates)
+        self.data = {**self.data, **updates, "last_updated": dt_util.now()}
+        if changed:
+            self.async_update_listeners()
+        _LOGGER.debug("Fast-polled %s for %s (changed=%s)", list(updates), self.vin, changed)
+
+        # LynkOS 1.4.0+ only refreshes location when the car stops, so when
+        # driving has just ended, chase the final (destination) location.
+        now_driving = (updates.get("vehicle_data") or {}).get("driveModeEnabled", False)
+        if was_driving and "vehicle_data" in updates and not now_driving:
+            self.hass.async_create_task(
+                self.async_targeted_refresh("location", lambda: self.api.get_location(self.vin))
+            )
 
     async def async_targeted_refresh(
         self,


### PR DESCRIPTION
Instead of refetching the whole snapshot when the car is busy, a fast-poll timer now refreshes only the relevant endpoints: while driving → location + drive state + battery (and a one-shot location fetch on arrival, since LynkOS 1.4.0+ only reports location at drive-end); while climate is active → climate state. The full snapshot still runs every 15 minutes as a backstop.