### PR TITLE
feat: add average electric consumption sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ When you perform an action (e.g. lock the doors or start the heaters), only the 
 #### Battery
 | Entity | Description | Unit | Model Availability |
 |---|---|---|---|
+| Average electric consumption | Average electric consumption | kWh/100km | All |
 | Battery capacity | Total battery capacity | kWh | All |
 | Battery energy | Current energy in battery (capacity × SoC) | kWh | All |
 | Battery level | State of charge | % | All |

--- a/custom_components/lynkco/sensor.py
+++ b/custom_components/lynkco/sensor.py
@@ -74,6 +74,15 @@ SENSOR_TYPES: list[dict] = [
         "value_fn": lambda d: _dig(d, "charge", "batteryState", "chargeLimit", "value"),
     },
     {
+        "key": "power_consumption",
+        "name": "Average electric consumption",
+        "icon": "mdi:meter-electric",
+        "device_class": None,
+        "unit": "kWh/100km",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "value_fn": lambda d: _dig(d, "charge", "batteryState", "powerAverageConsumption"),
+    },
+    {
         "key": "interior_temperature",
         "name": "Interior temperature",
         "icon": "mdi:thermometer",

--- a/custom_components/lynkco/strings.json
+++ b/custom_components/lynkco/strings.json
@@ -50,6 +50,7 @@
       "charging_speed": { "name": "Charging speed" },
       "charging_time_remaining": { "name": "Charging time remaining" },
       "charge_limit": { "name": "Charge limit" },
+      "power_consumption": { "name": "Average electric consumption" },
       "interior_temperature": { "name": "Interior temperature" },
       "target_temperature": { "name": "Target temperature" },
       "climate_status": { "name": "Climate status" },

--- a/custom_components/lynkco/translations/de.json
+++ b/custom_components/lynkco/translations/de.json
@@ -50,6 +50,7 @@
       "charging_speed": { "name": "Ladegeschwindigkeit" },
       "charging_time_remaining": { "name": "Verbleibende Ladezeit" },
       "charge_limit": { "name": "Ladelimit" },
+      "power_consumption": { "name": "Durchschnittlicher Stromverbrauch" },
       "interior_temperature": { "name": "Innentemperatur" },
       "target_temperature": { "name": "Zieltemperatur" },
       "climate_status": { "name": "Klimastatus" },

--- a/custom_components/lynkco/translations/en.json
+++ b/custom_components/lynkco/translations/en.json
@@ -50,6 +50,7 @@
       "charging_speed": { "name": "Charging speed" },
       "charging_time_remaining": { "name": "Charging time remaining" },
       "charge_limit": { "name": "Charge limit" },
+      "power_consumption": { "name": "Average electric consumption" },
       "interior_temperature": { "name": "Interior temperature" },
       "target_temperature": { "name": "Target temperature" },
       "climate_status": { "name": "Climate status" },

--- a/custom_components/lynkco/translations/es.json
+++ b/custom_components/lynkco/translations/es.json
@@ -50,6 +50,7 @@
       "charging_speed": { "name": "Velocidad de carga" },
       "charging_time_remaining": { "name": "Tiempo de carga restante" },
       "charge_limit": { "name": "Límite de carga" },
+      "power_consumption": { "name": "Consumo eléctrico medio" },
       "interior_temperature": { "name": "Temperatura interior" },
       "target_temperature": { "name": "Temperatura objetivo" },
       "climate_status": { "name": "Estado de la climatización" },

--- a/custom_components/lynkco/translations/fr.json
+++ b/custom_components/lynkco/translations/fr.json
@@ -50,6 +50,7 @@
       "charging_speed": { "name": "Vitesse de charge" },
       "charging_time_remaining": { "name": "Temps de charge restant" },
       "charge_limit": { "name": "Limite de charge" },
+      "power_consumption": { "name": "Consommation électrique moyenne" },
       "interior_temperature": { "name": "Température intérieure" },
       "target_temperature": { "name": "Température cible" },
       "climate_status": { "name": "État de la climatisation" },

--- a/custom_components/lynkco/translations/nl.json
+++ b/custom_components/lynkco/translations/nl.json
@@ -50,6 +50,7 @@
       "charging_speed": { "name": "Oplaadsnelheid" },
       "charging_time_remaining": { "name": "Resterende oplaadtijd" },
       "charge_limit": { "name": "Oplaadlimiet" },
+      "power_consumption": { "name": "Gemiddeld stroomverbruik" },
       "interior_temperature": { "name": "Interieurtemperatuur" },
       "target_temperature": { "name": "Doeltemperatuur" },
       "climate_status": { "name": "Klimaatstatus" },


### PR DESCRIPTION
Adds a sensor for `batteryState.powerAverageConsumption` from the `charge_state` endpoint - the electric counterpart to the existing average fuel consumption sensor.

- Entity: **Average electric consumption**, unit `kWh/100km`, state class `measurement`
- Available on all models (the field is present for both PHEV and BEV)
- Translations added for en/de/es/fr/nl, README sensor table updated

Found while investigating #28 - that issue asked for tripmeter 1/2 data, which the API does not expose at all.