### PR TITLE
feat: add update location button and action

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ When you perform an action (e.g. lock the doors or start the heaters), only the 
 
 ### Button
 - Refresh data — force an immediate refresh of all sensors from the device page
-- Update location — ask the car to report a fresh position (it answers within a few seconds, even when parked)
+- Update location - ask the car to report its current GPS location
 
 ### Actions (Services)
 
@@ -139,6 +139,9 @@ All actions (except `lynkco.refresh`) accept an optional `vin` parameter. When o
 | `lynkco.stop_heaters` | Stop heaters | `heaters` (list) | ✅ | t.b.c. | t.b.c. |
 | `lynkco.lock_glovebox` | Lock the glovebox | `pin` (4 digits) | ✅ | t.b.c. | t.b.c. |
 | `lynkco.unlock_glovebox` | Unlock the glovebox | | ✅ | t.b.c. | t.b.c. |
+
+#### Help needed
+⚠️ Please open an issue if you have verified a feature works which is marked as t.b.c. in this table so I can update the readme as confirmed working/not working.
 
 #### Notes:
 - ✅ = confirmed working on that model<br />

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ When you perform an action (e.g. lock the doors or start the heaters), only the 
 
 ### Button
 - Refresh data — force an immediate refresh of all sensors from the device page
+- Update location — ask the car to report a fresh position (it answers within a few seconds, even when parked)
 
 ### Actions (Services)
 
@@ -120,6 +121,7 @@ All actions (except `lynkco.refresh`) accept an optional `vin` parameter. When o
 | Service | Description | Parameters | 01 (facelift) | 02 | 08 |
 |---|---|---|---|---|---|
 | `lynkco.refresh` | Force-refresh all sensors now | | ✅ | ✅ | ✅ |
+| `lynkco.request_location` | Ask the car to report a fresh position | | ✅ | t.b.c. | t.b.c. |
 | `lynkco.lock_door` | Lock the vehicle's doors | | ✅ | ✅ | ✅ |
 | `lynkco.unlock_door` | Unlock the vehicle's doors | | ✅ | ✅ | ✅ |
 | `lynkco.flash_lights` | Flash the vehicle's lights | | ✅ | ✅ | t.b.c. |

--- a/custom_components/lynkco/__init__.py
+++ b/custom_components/lynkco/__init__.py
@@ -52,6 +52,7 @@ SERVICE_STOP_HEATERS = "stop_heaters"
 SERVICE_START_CONDITIONING = "start_conditioning"
 SERVICE_STOP_CONDITIONING = "stop_conditioning"
 SERVICE_REFRESH = "refresh"
+SERVICE_REQUEST_LOCATION = "request_location"
 SERVICE_LOCK_DOOR = "lock_door"
 SERVICE_UNLOCK_DOOR = "unlock_door"
 SERVICE_LOCK_GLOVEBOX = "lock_glovebox"
@@ -65,7 +66,7 @@ ALL_SERVICES = [
     SERVICE_START_VENTILATE, SERVICE_STOP_VENTILATE,
     SERVICE_START_HEATERS, SERVICE_STOP_HEATERS,
     SERVICE_START_CONDITIONING, SERVICE_STOP_CONDITIONING,
-    SERVICE_REFRESH,
+    SERVICE_REFRESH, SERVICE_REQUEST_LOCATION,
     SERVICE_LOCK_DOOR, SERVICE_UNLOCK_DOOR,
     SERVICE_LOCK_GLOVEBOX, SERVICE_UNLOCK_GLOVEBOX,
 ]
@@ -290,6 +291,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await _get_api(hass, vin).unlock_glovebox(vin)
             _targeted_refresh(hass, vin, "vehicle_data", "get_vehicle_data")
 
+        async def handle_request_location(call: ServiceCall) -> None:
+            vin = _resolve_vin(hass, call)
+            await _get_api(hass, vin).request_location(vin)
+            _targeted_refresh(hass, vin, "location", "get_location")
+
         async def handle_refresh(call: ServiceCall) -> None:
             vin = _resolve_vin(hass, call)
             coordinator = _get_coordinator(hass, vin)
@@ -315,6 +321,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_register(DOMAIN, SERVICE_UNLOCK_DOOR, handle_unlock_door, VIN_SCHEMA)
         hass.services.async_register(DOMAIN, SERVICE_LOCK_GLOVEBOX, handle_lock_glovebox, GLOVEBOX_LOCK_SCHEMA)
         hass.services.async_register(DOMAIN, SERVICE_UNLOCK_GLOVEBOX, handle_unlock_glovebox, VIN_SCHEMA)
+        hass.services.async_register(DOMAIN, SERVICE_REQUEST_LOCATION, handle_request_location, VIN_SCHEMA)
         hass.services.async_register(DOMAIN, SERVICE_REFRESH, handle_refresh, VIN_SCHEMA)
 
     return True

--- a/custom_components/lynkco/api.py
+++ b/custom_components/lynkco/api.py
@@ -216,6 +216,17 @@ class LynkCoAPI:
             "POST", f"{COMMAND_BASE}/vehicle/{vin}/command/door_unlock"
         )
 
+    async def request_location(self, vin: str) -> dict:
+        """Ask the vehicle to report its current position.
+
+        Declared but never called by the official app (v2.63.0); verified working
+        against the live API. The car answers COMMAND_RECEIVED immediately and
+        pushes a fresh position a few seconds later.
+        """
+        return await self._request(
+            "POST", f"{COMMAND_BASE}/vehicle/{vin}/command/request_location"
+        )
+
     async def flash_lights(self, vin: str) -> dict:
         return await self._request(
             "POST", f"{COMMAND_BASE}/vehicle/{vin}/command/flash_lights"

--- a/custom_components/lynkco/button.py
+++ b/custom_components/lynkco/button.py
@@ -21,24 +21,25 @@ async def async_setup_entry(
     entities = []
     for vin, coordinator in data["coordinators"].items():
         entities.append(LynkCoRefreshButton(coordinator))
+        entities.append(LynkCoRequestLocationButton(coordinator))
     async_add_entities(entities)
 
 
-class LynkCoRefreshButton(ButtonEntity):
-    """Button that forces an immediate data refresh.
+class LynkCoButton(ButtonEntity):
+    """Base for the integration's buttons.
 
-    Deliberately not a CoordinatorEntity so it stays available even after a
-    failed poll — that's exactly when a manual refresh is most useful.
+    Deliberately not a CoordinatorEntity so buttons stay available even after a
+    failed poll — that's exactly when they're most useful.
     """
 
     _attr_has_entity_name = True
-    _attr_translation_key = "refresh"
-    _attr_icon = "mdi:refresh"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _key: str
 
     def __init__(self, coordinator: LynkCoCoordinator) -> None:
         self.coordinator = coordinator
-        self._attr_unique_id = f"{coordinator.vin}_refresh"
+        self._attr_unique_id = f"{coordinator.vin}_{self._key}"
+        self._attr_translation_key = self._key
 
     @property
     def device_info(self):
@@ -50,6 +51,31 @@ class LynkCoRefreshButton(ButtonEntity):
             "serial_number": self.coordinator.vin,
         }
 
+
+class LynkCoRefreshButton(LynkCoButton):
+    """Button that forces an immediate data refresh."""
+
+    _attr_icon = "mdi:refresh"
+    _key = "refresh"
+
     async def async_press(self) -> None:
         _LOGGER.info("Manual refresh requested for %s", self.coordinator.vin)
         await self.coordinator.async_request_refresh()
+
+
+class LynkCoRequestLocationButton(LynkCoButton):
+    """Button that asks the vehicle to report a fresh position."""
+
+    _attr_icon = "mdi:crosshairs-gps"
+    _key = "request_location"
+
+    async def async_press(self) -> None:
+        _LOGGER.info("Location update requested for %s", self.coordinator.vin)
+        await self.coordinator.api.request_location(self.coordinator.vin)
+        # The car acknowledges immediately but pushes the position a few seconds
+        # later, so chase it in the background instead of blocking the press.
+        self.hass.async_create_task(
+            self.coordinator.async_targeted_refresh(
+                "location", lambda: self.coordinator.api.get_location(self.coordinator.vin)
+            )
+        )

--- a/custom_components/lynkco/services.yaml
+++ b/custom_components/lynkco/services.yaml
@@ -4,6 +4,12 @@ refresh:
       selector:
         text:
 
+request_location:
+  fields:
+    vin:
+      selector:
+        text:
+
 flash_lights:
   fields:
     vin:

--- a/custom_components/lynkco/strings.json
+++ b/custom_components/lynkco/strings.json
@@ -101,7 +101,8 @@
       "climate": { "name": "Climate" }
     },
     "button": {
-      "refresh": { "name": "Refresh data" }
+      "refresh": { "name": "Refresh data" },
+      "request_location": { "name": "Update location" }
     },
     "device_tracker": {
       "location": { "name": "Location" }
@@ -111,6 +112,16 @@
     "refresh": {
       "name": "Refresh sensors",
       "description": "Force an immediate refresh of all vehicle sensors.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Vehicle Identification Number (optional if only one vehicle)"
+        }
+      }
+    },
+    "request_location": {
+      "name": "Update location",
+      "description": "Ask the vehicle to report its current position.",
       "fields": {
         "vin": {
           "name": "VIN",

--- a/custom_components/lynkco/translations/de.json
+++ b/custom_components/lynkco/translations/de.json
@@ -101,7 +101,8 @@
       "climate": { "name": "Klimatisierung" }
     },
     "button": {
-      "refresh": { "name": "Daten aktualisieren" }
+      "refresh": { "name": "Daten aktualisieren" },
+      "request_location": { "name": "Standort aktualisieren" }
     },
     "device_tracker": {
       "location": { "name": "Standort" }
@@ -111,6 +112,16 @@
     "refresh": {
       "name": "Sensoren aktualisieren",
       "description": "Erzwingt eine sofortige Aktualisierung aller Fahrzeugsensoren.",
+      "fields": {
+        "vin": {
+          "name": "FIN",
+          "description": "Fahrzeug-Identifizierungsnummer (optional bei nur einem Fahrzeug)"
+        }
+      }
+    },
+    "request_location": {
+      "name": "Standort aktualisieren",
+      "description": "Das Fahrzeug auffordern, seine aktuelle Position zu melden.",
       "fields": {
         "vin": {
           "name": "FIN",

--- a/custom_components/lynkco/translations/en.json
+++ b/custom_components/lynkco/translations/en.json
@@ -101,7 +101,8 @@
       "climate": { "name": "Climate" }
     },
     "button": {
-      "refresh": { "name": "Refresh data" }
+      "refresh": { "name": "Refresh data" },
+      "request_location": { "name": "Update location" }
     },
     "device_tracker": {
       "location": { "name": "Location" }
@@ -111,6 +112,16 @@
     "refresh": {
       "name": "Refresh sensors",
       "description": "Force an immediate refresh of all vehicle sensors.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Vehicle Identification Number (optional if only one vehicle)"
+        }
+      }
+    },
+    "request_location": {
+      "name": "Update location",
+      "description": "Ask the vehicle to report its current position.",
       "fields": {
         "vin": {
           "name": "VIN",

--- a/custom_components/lynkco/translations/es.json
+++ b/custom_components/lynkco/translations/es.json
@@ -101,7 +101,8 @@
       "climate": { "name": "Climatización" }
     },
     "button": {
-      "refresh": { "name": "Actualizar datos" }
+      "refresh": { "name": "Actualizar datos" },
+      "request_location": { "name": "Actualizar ubicación" }
     },
     "device_tracker": {
       "location": { "name": "Ubicación" }
@@ -111,6 +112,16 @@
     "refresh": {
       "name": "Actualizar sensores",
       "description": "Forzar una actualización inmediata de todos los sensores del vehículo.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Número de identificación del vehículo (opcional si solo hay un vehículo)"
+        }
+      }
+    },
+    "request_location": {
+      "name": "Actualizar ubicación",
+      "description": "Pedir al vehículo que informe de su posición actual.",
       "fields": {
         "vin": {
           "name": "VIN",

--- a/custom_components/lynkco/translations/fr.json
+++ b/custom_components/lynkco/translations/fr.json
@@ -101,7 +101,8 @@
       "climate": { "name": "Climatisation" }
     },
     "button": {
-      "refresh": { "name": "Actualiser les données" }
+      "refresh": { "name": "Actualiser les données" },
+      "request_location": { "name": "Actualiser la position" }
     },
     "device_tracker": {
       "location": { "name": "Position" }
@@ -111,6 +112,16 @@
     "refresh": {
       "name": "Actualiser les capteurs",
       "description": "Forcer une actualisation immédiate de tous les capteurs du véhicule.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Numéro d'identification du véhicule (optionnel si un seul véhicule)"
+        }
+      }
+    },
+    "request_location": {
+      "name": "Actualiser la position",
+      "description": "Demander au véhicule de signaler sa position actuelle.",
       "fields": {
         "vin": {
           "name": "VIN",

--- a/custom_components/lynkco/translations/nl.json
+++ b/custom_components/lynkco/translations/nl.json
@@ -101,7 +101,8 @@
       "climate": { "name": "Klimaatregeling" }
     },
     "button": {
-      "refresh": { "name": "Gegevens vernieuwen" }
+      "refresh": { "name": "Gegevens vernieuwen" },
+      "request_location": { "name": "Locatie bijwerken" }
     },
     "device_tracker": {
       "location": { "name": "Locatie" }
@@ -111,6 +112,16 @@
     "refresh": {
       "name": "Sensoren vernieuwen",
       "description": "Forceer een directe vernieuwing van alle voertuigsensoren.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Voertuigidentificatienummer (optioneel bij slechts 1 geconfigureerd voertuig)"
+        }
+      }
+    },
+    "request_location": {
+      "name": "Locatie bijwerken",
+      "description": "Vraag de auto om zijn huidige positie te melden.",
       "fields": {
         "vin": {
           "name": "VIN",


### PR DESCRIPTION
Adds  an action to request a new location from the car. This asks the car to report a fresh position on demand, rather than waiting for the next poll (and on LynkOS 1.4.0+ the car otherwise only reports location when it stops driving).

This endpoint is **declared in the official app (v2.63.0) but never called by it**. 

### What's added

- **Button** `Update location` on the device page
- **Action** `lynkco.request_location` with the usual optional `vin`
- Both fire the command and then chase the result with a targeted `location` refresh in the background (3s / 8s / 18s retries), so the device tracker and address sensor should pick up the new position automatically.
- Translations for en/de/es/fr/nl, README button list + actions table updated

Confirmed working on a 01 PHEV; 02 / 08 marked t.b.c. in the README table. Since the app never calls this endpoint, be aware Lynk & Co could change it without an app release signalling it.